### PR TITLE
Update README and add docker-compose to work with MapR Container for Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ $ cd webserver-service
 
 $ docker build -t mapr-web-consumer .
 
-$ docker run -it --privileged --cap-add SYS_ADMIN --cap-add SYS_RESOURCE --device /dev/fuse -p 8082:8080  -e MAPR_CLDB_HOSTS=host.docker.internal -e MAPR_CLUSTER=maprdemo.mapr.io -e MAPR_CONTAINER_USER=mapr -e MAPR_MOUNT_PATH=/mapr --name web -i -t mapr-web-consumer
+$ docker run -it --privileged --cap-add SYS_ADMIN --cap-add SYS_RESOURCE --device /dev/fuse -p 8080:8080  -e MAPR_CLDB_HOSTS=host.docker.internal -e MAPR_CLUSTER=maprdemo.mapr.io -e MAPR_CONTAINER_USER=mapr -e MAPR_MOUNT_PATH=/mapr --name web -i -t mapr-web-consumer
 
 
 ```
 
-Alternatively, after following the build steps above, you can use the provided `docker-compose.yml`
-file and bring up the Sensor and Web applications by running:
+Alternatively, after building the Java applications with `mvn`, you can use the `docker-compose.yml`
+file to run the Sensor and Web applications running a local instance of the
+[MapR Container for Developers](https://maprdocs.mapr.com/home/MapRContainerDevelopers/MapRContainerDevelopersOverview.html).
 
 ```
 $ docker-compose up

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ $ docker run -it --privileged --cap-add SYS_ADMIN --cap-add SYS_RESOURCE --devic
 
 ```
 
+Alternatively, after following the build steps above, you can use the provided `docker-compose.yml`
+file and bring up the Sensor and Web applications by running:
+
+```
+$ docker-compose up
+
+```
+
 Access the Web application in the host using http://localhost:8080
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ maprcli stream topic create -path /apps/sensors -topic computer
 Create a directory to store application logs
 
 ```
-$ mkdir -p /mapr/my.cluster.com/apps/logs
+$ mkdir -p /mapr/maprdemo.mapr.io/apps/logs
 ```
 
 
@@ -35,7 +35,7 @@ $ cd sensor-service
 
 $ docker build -t mapr-sensor-producer .
 
-$ docker run -it -e MAPR_CLDB_HOSTS=192.168.99.18 -e MAPR_CLUSTER=my.cluster.com -e MAPR_CONTAINER_USER=mapr --name producer -i -t mapr-sensor-producer
+$ docker run -it -e MAPR_CLDB_HOSTS=host.docker.internal -e MAPR_CLUSTER=maprdemo.mapr.io -e MAPR_CONTAINER_USER=mapr --name producer -i -t mapr-sensor-producer
 
 ```
 
@@ -46,7 +46,7 @@ $ cd webserver-service
 
 $ docker build -t mapr-web-consumer .
 
-$ docker run -it --privileged --cap-add SYS_ADMIN --cap-add SYS_RESOURCE --device /dev/fuse -p 8080:8080  -e MAPR_CLDB_HOSTS=192.168.99.18 -e MAPR_CLUSTER=my.cluster.com -e MAPR_CONTAINER_USER=mapr -e MAPR_MOUNT_PATH=/mapr --name web -i -t mapr-web-consumer
+$ docker run -it --privileged --cap-add SYS_ADMIN --cap-add SYS_RESOURCE --device /dev/fuse -p 8082:8080  -e MAPR_CLDB_HOSTS=host.docker.internal -e MAPR_CLUSTER=maprdemo.mapr.io -e MAPR_CONTAINER_USER=mapr -e MAPR_MOUNT_PATH=/mapr --name web -i -t mapr-web-consumer
 
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# Docker Compose file for testing against the [MapR Container for Developers](https://maprdocs.mapr.com/home/MapRContainerDevelopers/MapRContainerDevelopersOverview.html)
+
+# Connect UI to http://localhost:8082 to see "Last messages - refreshed every 3 seconds"
+
+version: "3"
+
+services:
+
+  producer:
+    network_mode: "bridge"
+    build:
+      context: sensor-service
+    image: maprtech/mapr-pacc-sample-sensor-producer:0.1
+    environment:
+      - MAPR_CLDB_HOSTS=host.docker.internal
+      - MAPR_CLUSTER=maprdemo.mapr.io
+      - MAPR_CONTAINER_USER=mapr
+    
+
+  web:
+    network_mode: "bridge"
+    privileged: true
+    cap_add:
+      - SYS_ADMIN
+      - SYS_RESOURCE
+    devices:
+      - /dev/fuse
+    build:
+      context: webserver-service
+    image: maprtech/mapr-pacc-sample-web-consumer:0.1
+    environment:
+      - MAPR_CLDB_HOSTS=host.docker.internal
+      - MAPR_CLUSTER=maprdemo.mapr.io
+      - MAPR_CONTAINER_USER=mapr
+      - MAPR_MOUNT_PATH=/mapr
+    ports:
+      - "8082:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Docker Compose file for testing against the [MapR Container for Developers](https://maprdocs.mapr.com/home/MapRContainerDevelopers/MapRContainerDevelopersOverview.html)
 
-# Connect UI to http://localhost:8082 to see "Last messages - refreshed every 3 seconds"
+# Connect UI to http://localhost:8080 to see "Last messages - refreshed every 3 seconds"
 
 version: "3"
 
@@ -34,4 +34,4 @@ services:
       - MAPR_CONTAINER_USER=mapr
       - MAPR_MOUNT_PATH=/mapr
     ports:
-      - "8082:8080"
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     network_mode: "bridge"
     build:
       context: sensor-service
-    image: maprtech/mapr-pacc-sample-sensor-producer:0.1
+    image: mapr-sensor-producer
     environment:
       - MAPR_CLDB_HOSTS=host.docker.internal
       - MAPR_CLUSTER=maprdemo.mapr.io
@@ -27,7 +27,7 @@ services:
       - /dev/fuse
     build:
       context: webserver-service
-    image: maprtech/mapr-pacc-sample-web-consumer:0.1
+    image: mapr-web-consumer
     environment:
       - MAPR_CLDB_HOSTS=host.docker.internal
       - MAPR_CLUSTER=maprdemo.mapr.io


### PR DESCRIPTION
In testing the mapr-pacc-sample against the [MapR Container for Developers](https://maprdocs.mapr.com/home/MapRContainerDevelopers/MapRContainerDevelopersOverview.html) I had to make some changes, and I wanted to automate the setup with `docker-compose`. I thought these changes might be helpful to others.

Note, this is tested on recent Docker for Mac 18.03.0-ce-mac60 (23751).